### PR TITLE
Embedded activation of C#8 and NUllable feature in the package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+# v1.4.0
+
+Nullable feature is now automatically enabled by default.
+
+* For legacy frameworks (before NetCoreApp3.0/NetStandard2.1) warnings won't be raised:
+`<Nullable>Annotation</Nullable>`
+* While full activation is done only for recent frameworks (NetCoreApp3.0/NetStandard2.1 or more recent):
+`<Nullable>Enable</Nullable>`
+* And in all cases C# version is defined to use last version: `<LangVersion>Latest</LangVersion>`
+
+This are default values that are used if you do not override them in your csproj file.
+They have been chosen to match the most common use case which is multi-targeted projects that target recent frameworks that will produce the warnings and legacy frameworks that will just be annotated ignoring warnings related to the fact that the frameworks are not annotated. 
+
 # v1.3.0
 
 This release adds support for .NET 5's `MemberNotNullAttribute` and `MemberNotNullWhenAttribute`.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,6 @@ install the package for your target framework.
 
 ## Quickstart
 
-> :warning: **Important:** <br/>
-> You **must** use a C# version >= 8.0 with the `Nullable` package - otherwise, your project won't compile.
-
 The steps below assume that you are using the **new SDK `.csproj`** style.
 Please find installation guides and notes for other project types (for example `packages.config`)
 [here](https://github.com/manuelroemer/Nullable/wiki).
@@ -86,7 +83,31 @@ Please find installation guides and notes for other project types (for example `
 
    This is especially important for libraries that are published to NuGet, because without this,
    the library will have an **explicit dependency** on the `Nullable` package.
-3. **Build the project** <br/>
+3. **Ensure that your are using at least C#8** <br/>
+   You **must** use a C# version >= 8.0 with the `Nullable` package - otherwise, your project won't compile. <br/>
+   If you never specified the `<LangVersion>` property in you csproj, it's fine the package will setup it for you. Otherwise remove the tag, or update it to what you want to overload the value defined by the package.
+
+   By default the `Nullable` package declare for legacy frameworks (before NetCoreApp3.0/NetStandard2.1):
+
+   ```xml
+   <PropertyGroup>
+      <!-- so you can use nullable annotations but the compiler won't produce warnings -->
+      <!-- common use case is a multi-targeted project where warnings are produced only on recent -->
+      <!-- frameworks because they are annotated which avoid false positives on legacy frameworks.  -->
+     <Nullable>annotations</Nullable>
+     <LangVersion>Latest</LangVersion>
+   </PropertyGroup>
+   ```
+   and for recent frameworks (since NetCoreApp3.0/NetStandard2.1):
+
+   ```xml
+   <PropertyGroup>
+     <Nullable>enable</Nullable>
+     <LangVersion>Latest</LangVersion>
+   </PropertyGroup>
+   ```
+
+4. **Build the project** <br/>
    Ensure that the project compiles. If a build error occurs, you will most likely have to update
    the C# language version.
 

--- a/src/Build/Annotations.props
+++ b/src/Build/Annotations.props
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Nullable>annotations</Nullable>
+    <LangVersion>Latest</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Build/Enable.props
+++ b/src/Build/Enable.props
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <LangVersion>Latest</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/src/Nullable.nuspec
+++ b/src/Nullable.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Nullable</id>
-    <version>1.3.0-preview1</version>
+    <version>1.4.0-preview1</version>
     <developmentDependency>true</developmentDependency>
     <authors>Manuel Römer</authors>
     <license type="expression">MIT</license>
@@ -36,6 +36,7 @@ Please see https://github.com/manuelroemer/Nullable for additional information o
     -->
 
     <!-- >= .NET Standard 1.0 and >= .NET 1.0 require all attributes and don't support ExcludeFromCodeCoverageAttribute. -->
+    <!-- and only annotations are activated by default, no warnings, since framework is not annoted -->
     <file src="NoExcludeFromCodeCoverage/AllowNullAttribute.cs.pp" target="contentFiles/cs/netstandard1.0/Nullable/AllowNullAttribute.cs.pp"/>
     <file src="NoExcludeFromCodeCoverage/DisallowNullAttribute.cs.pp" target="contentFiles/cs/netstandard1.0/Nullable/DisallowNullAttribute.cs.pp"/>
     <file src="NoExcludeFromCodeCoverage/DoesNotReturnAttribute.cs.pp" target="contentFiles/cs/netstandard1.0/Nullable/DoesNotReturnAttribute.cs.pp"/>
@@ -60,8 +61,9 @@ Please see https://github.com/manuelroemer/Nullable for additional information o
     <file src="NoExcludeFromCodeCoverage/NotNullIfNotNullAttribute.cs.pp" target="content/netstandard1.0/Nullable/NotNullIfNotNullAttribute.cs.pp"/>
     <file src="NoExcludeFromCodeCoverage/NotNullWhenAttribute.cs.pp" target="content/netstandard1.0/Nullable/NotNullWhenAttribute.cs.pp"/>
 
+    <file src="../../src/Build/Annotations.props" target="build/netstandard1.0/Nullable.props"/>
 
-      
+
     <file src="NoExcludeFromCodeCoverage/AllowNullAttribute.cs.pp" target="contentFiles/cs/net20/Nullable/AllowNullAttribute.cs.pp"/>
     <file src="NoExcludeFromCodeCoverage/DisallowNullAttribute.cs.pp" target="contentFiles/cs/net20/Nullable/DisallowNullAttribute.cs.pp"/>
     <file src="NoExcludeFromCodeCoverage/DoesNotReturnAttribute.cs.pp" target="contentFiles/cs/net20/Nullable/DoesNotReturnAttribute.cs.pp"/>
@@ -86,9 +88,11 @@ Please see https://github.com/manuelroemer/Nullable for additional information o
     <file src="NoExcludeFromCodeCoverage/NotNullIfNotNullAttribute.cs.pp" target="content/net20/Nullable/NotNullIfNotNullAttribute.cs.pp"/>
     <file src="NoExcludeFromCodeCoverage/NotNullWhenAttribute.cs.pp" target="content/net20/Nullable/NotNullWhenAttribute.cs.pp"/>
 
+    <file src="../../src/Build/Annotations.props" target="build/net20/Nullable.props"/>
 
-      
+
     <!-- >= .NET Standard 2.0 and >= .NET 4.0 require all attributes and support ExcludeFromCodeCoverageAttribute. -->
+    <!-- and only annotations are activated by default, no warnings, since framework is not annoted -->
     <file src="ExcludeFromCodeCoverage/AllowNullAttribute.cs.pp" target="contentFiles/cs/netstandard2.0/Nullable/AllowNullAttribute.cs.pp"/>
     <file src="ExcludeFromCodeCoverage/DisallowNullAttribute.cs.pp" target="contentFiles/cs/netstandard2.0/Nullable/DisallowNullAttribute.cs.pp"/>
     <file src="ExcludeFromCodeCoverage/DoesNotReturnAttribute.cs.pp" target="contentFiles/cs/netstandard2.0/Nullable/DoesNotReturnAttribute.cs.pp"/>
@@ -113,8 +117,9 @@ Please see https://github.com/manuelroemer/Nullable for additional information o
     <file src="NoExcludeFromCodeCoverage/NotNullIfNotNullAttribute.cs.pp" target="content/netstandard2.0/Nullable/NotNullIfNotNullAttribute.cs.pp"/>
     <file src="NoExcludeFromCodeCoverage/NotNullWhenAttribute.cs.pp" target="content/netstandard2.0/Nullable/NotNullWhenAttribute.cs.pp"/>
 
+    <file src="../../src/Build/Annotations.props" target="build/netstandard2.0/Nullable.props"/>
 
-      
+
     <file src="ExcludeFromCodeCoverage/AllowNullAttribute.cs.pp" target="contentFiles/cs/net40/Nullable/AllowNullAttribute.cs.pp"/>
     <file src="ExcludeFromCodeCoverage/DisallowNullAttribute.cs.pp" target="contentFiles/cs/net40/Nullable/DisallowNullAttribute.cs.pp"/>
     <file src="ExcludeFromCodeCoverage/DoesNotReturnAttribute.cs.pp" target="contentFiles/cs/net40/Nullable/DoesNotReturnAttribute.cs.pp"/>
@@ -139,21 +144,24 @@ Please see https://github.com/manuelroemer/Nullable for additional information o
     <file src="NoExcludeFromCodeCoverage/NotNullIfNotNullAttribute.cs.pp" target="content/net40/Nullable/NotNullIfNotNullAttribute.cs.pp"/>
     <file src="NoExcludeFromCodeCoverage/NotNullWhenAttribute.cs.pp" target="content/net40/Nullable/NotNullWhenAttribute.cs.pp"/>
 
+    <file src="../../src/Build/Annotations.props" target="build/net40/Nullable.props"/>
 
-      
+
     <!-- >= .NET Standard 2.1 only requires MemberNotNullAttribute and MemberNotNullWhenAttribute. -->
+    <!-- and nullable are fully activated by default, since framework is mostly annnoted -->
     <file src="ExcludeFromCodeCoverage/MemberNotNullAttribute.cs.pp" target="contentFiles/cs/netstandard2.1/Nullable/MemberNotNullAttribute.cs.pp"/>
     <file src="ExcludeFromCodeCoverage/MemberNotNullWhenAttribute.cs.pp" target="contentFiles/cs/netstandard2.1/Nullable/MemberNotNullWhenAttribute.cs.pp"/>
 
     <file src="NoExcludeFromCodeCoverage/MemberNotNullAttribute.cs.pp" target="content/netstandard2.1/Nullable/MemberNotNullAttribute.cs.pp"/>
     <file src="NoExcludeFromCodeCoverage/MemberNotNullWhenAttribute.cs.pp" target="content/netstandard2.1/Nullable/MemberNotNullWhenAttribute.cs.pp"/>
 
+    <file src="../../src/Build/Enable.props" target="build/netstandard2.1/Nullable.props"/>
 
-      
-    <!-- >= .NET 5 has all attributes. -->
+
+    <!-- >= .NET 5 has all attributes. We just need to activate the feature. -->
     <file src="../../src/.nuget/_._" target="contentFiles/cs/net5.0"/>
     <file src="../../src/.nuget/_._" target="content/net5.0"/>
-
+    <file src="../../src/Build/Enable.props" target="build/net5.0/Nullable.props"/>
 
 
     <!-- Package icon. -->


### PR DESCRIPTION
I discover this package after having read this blog post:
https://endjin.com/blog/2020/07/dotnet-csharp-8-nullable-references-supporting-older-runtimes

It clearly simplify a lot the support of a private enterprise library because before that we were using a lot of `#if` instructions to annotate the library for recent frameworks and keep supporting older frameworks.

But in that blog post there is a trick which is not easy to guess and on which this package could help:
The variability of the activation level of the feature: `<Nullable>enable</Nullable>` vs `<Nullable>annotations</Nullable>`

Note that we have a lot of libraries in which we want to add support of nullable, and that this scenario is probably the most common one for people looking for a package like that one. So I though it could be great if the package natively guide us in that direction.

It worked fine in multiple use cases I've tested, and we can override it in csproj if we want.

The only limitation i've found is on legacy csproj (not SDK style) where the `Nullable` tag seems to be not interpreted, but the `LangVersion` tag works so even in that case it's already a better experience for the developer since he could work with nullable right after having added the package (by using `#nullable` directive in the cs files), it's no more required for him to set the LangVersion manually.